### PR TITLE
Function inlining error fix

### DIFF
--- a/extras/usb-redirector.sh
+++ b/extras/usb-redirector.sh
@@ -25,6 +25,8 @@ install_usb_redirector()
 	cd $SOURCES/usb-redirector-linux-arm-eabi/files/modules/src/tusbd
 	# patch to work with newer kernels
 	sed -e "s/f_dentry/f_path.dentry/g" -i usbdcdev.c
+	# Remove inlining for now, as function body must have been defined in utils.h:
+	sed -e 's/inline int/int/g' -i utils.h utils.c
 	if [[ $ARCH == *64* ]]; then ARCHITECTURE=arm64; else ARCHITECTURE=arm; fi
 	make -j1 ARCH=$ARCHITECTURE CROSS_COMPILE="$CCACHE $KERNEL_COMPILER" KERNELDIR=$SOURCES/$LINUXSOURCEDIR/ >> $DEST/debug/install.log 2>&1
 	# configure USB redirector


### PR DESCRIPTION
A quick fix for the "inlining failed in call to always_inline, function body not available" error by removing the "inline" attribute.

Whileas this makes tusbd.ko compile, it might lead into lesser performance due to these functions not being inlined, as optimisation is now up to the compiler.

Maybe someone is willing to fiddle with the obfuscated code or find a real free, open source implementation ...
